### PR TITLE
Avertissement lors de la compilation (geometry package)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021, n3rada
+Copyright (c) 2023, n3rada
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/rUTT.cls
+++ b/rUTT.cls
@@ -494,13 +494,9 @@ boxsep=4pt, left=0pt,right=0pt,top=0pt,bottom=0pt,colframe=white,colback=lightgr
   a4paper,
   %showframe, % show the page layout
   %includeheadfoot, % la zone de texte inclut le header et le footer
-  textwidth=16cm,
   headheight=8cm,
   headsep=0.5cm,
-  top=2.54cm,
-  bottom=2.54cm,
-  left=2.54cm,
-  right=2.54cm,
+  margin=2.54cm,
   footskip=1.25cm
 ]{geometry}   % Utilisé pour les marges
 


### PR DESCRIPTION
Une manière plus efficace de définir les marges est d'utiliser `margin` plutôt que des les définir une à une lorsqu'elles sont toutes identiques.
`textwidth` est redondant avec la définition des marges, ce qui causait un avertissement lors de la compilation.
Il est automatiquement calculé en fonction de la taille d'une page (feuille A4) et de la taille des marges.