### PR TITLE
Déploiement

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ jobs:
         steps:
             -   name: Checkout repo
                 uses: actions/checkout@v4
-            -   name: Upload zip
+            -   name: Upload artifact
                 uses: actions/upload-artifact@v4
                 with:
                     name: deploy
@@ -21,3 +21,23 @@ jobs:
                         Makefile
                         rapportUTT.tex
                         rUTT.cls
+            -   name: Create draft release
+                env:
+                    GH_TOKEN: ${{ github.token }}
+                run: |
+                    zip -qr deploy.zip \
+                    assets/ \
+                    latex-files/ \
+                    packages/ \
+                    ressources-graphiques/ \
+                    .latexmkrc \
+                    Makefile \
+                    rapportUTT.tex \
+                    rUTT.cls && \
+                    for DRAFT_TAG in $(gh release list --limit 100 --json tagName,isDraft --jq '.[] | select(.isDraft) | .tagName'); do \
+                        gh release delete "$DRAFT_TAG" -y; \
+                    done; YEAR_MONTH=$(date "+%Y.%-m"); COUNT=0; \
+                    for TAG in $(gh release list --exclude-drafts --limit 100 | awk '{print $1}'); do \
+                        case "$TAG" in v"$YEAR_MONTH".*) COUNT=$((COUNT + 1));; esac; \
+                    done; RELEASE_NUMBER=$((COUNT + 1)); \
+                    gh release create --draft --generate-notes "v$YEAR_MONTH.$RELEASE_NUMBER" deploy.zip

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Voici la couverture que vous obtiendrez en utilisant ce projet :
 ## Utilisation
 
 **Pour une utilisation simple, ne téléchargez pas directement tout le repository !**
-Téléchargez [l'archive prête à être utilisée](https://nightly.link/n3rada/ScribUTT/workflows/deploy.yaml/main/deploy.zip).
+Téléchargez [l'archive prête à être utilisée](https://github.com/n3rada/ScribUTT/releases/latest/download/deploy.zip).
 
 ## Bivalence
 


### PR DESCRIPTION
On m'a fait remarqué que l'artifact n'était plus valide étant donné qu'ils ne restent disponibles que 90 jours.
Je propose donc d'utiliser l'onglet releases qui est peut-être plus proche de ce que l'on cherche pour un projet stable.
Cela va vérifier qu'il n'y a pas de draft existante sinon cela les supprime puis cela crée une draft release avec en version vYYYY.M.N (YYYY l'année, M le mois et N le numéro de la release dans le mois), je me suis dis que le semantic versioning n'était pas vraiment approprié mais je te laisse décider. J'hésitais à juste mettre année puis numéro de la release dans l'année.
Si jamais tu veux publier la release, il te suffit de te rendre dans releases, cliquer sur la draft release, éventuellement la modifier, et la publier.
J'ai laissé la création d'artifact (l'étape peut être retirée sans soucis).
Lié à #14