### PR TITLE
fix: warning for datatool version 3+

### DIFF
--- a/rUTT.cls
+++ b/rUTT.cls
@@ -215,6 +215,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Glossaire
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\usepackage[lang-warn=false]{datatool-base}
 \usepackage[acronym, toc, xindy, ucmark]{glossaries}
 % Uncomment this if you want to make glossary
 % \makeglossaries


### PR DESCRIPTION
The warning was this:
`Package tracklang Warning: No 'datatool' support for dialect 'french' on input line 9908.`
However the glossaries package doesn't use this localisation feature from datatool.