### PR TITLE
Workflow update

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,15 +10,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout repo
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
             -   name: Create zip
                 run: make archive
             -   name: Upload artifact
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v7
                 with:
-                    name: deploy
-                    include-hidden-files: true
-                    path: build/
+                    archive: false
+                    path: deploy.zip
             -   name: Create draft release
                 env:
                     GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,12 @@
-name: deploy
+name: Create draft release
 
 on:
     push:
         branches:
             - main
+
+permissions:
+    contents: write
 
 jobs:
     deploy:
@@ -11,6 +14,8 @@ jobs:
         steps:
             -   name: Checkout repo
                 uses: actions/checkout@v6
+                with:
+                    persist-credentials: false
             -   name: Create zip
                 run: make archive
             -   name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ rapportUTT.*
 !rapportUTT.tex
 !rapportUTT.pdf
 *temp*
+build/
+deploy.zip


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/deploy.yaml` to improve the release process and modernize dependencies. The workflow is now focused on creating a draft release, and several steps and actions have been updated for better security and compatibility.

**Workflow improvements:**

* Renamed the workflow from "deploy" to "Create draft release".
* Added `contents: write` permission to allow the workflow to create releases.

**Dependency and action updates:**

* Upgraded `actions/checkout` from v4 to v6 and disabled credential persistence for improved security.
* Upgraded `actions/upload-artifact` from v4 to v7, changed the `path` to use `deploy.zip`, and set `archive: false` to match the new artifact structure.

**Artifact handling:**

* The workflow now creates a zip archive using `make archive` and uploads `deploy.zip` as the artifact instead of the entire `build/` directory.